### PR TITLE
Update LarsonScanners.py

### DIFF
--- a/BiblioPixelAnimations/strip/LarsonScanners.py
+++ b/BiblioPixelAnimations/strip/LarsonScanners.py
@@ -19,6 +19,8 @@ class LarsonScanner(BaseStripAnim):
 
         self._direction = -1
         self._last = 0
+        if self._tail == 0:
+            self._tail = 1
         self._fadeAmt = 256 / self._tail
 
     def step(self, amt = 1):


### PR DESCRIPTION
Hi,
when using a strip size of 3 or less LED i get a division by Zero , because of this:

16        self._tail = tail + 1  # makes tail math later easier
 17       if self._tail >= self._size / 2:
  18          self._tail = (self._size / 2) - 1

  File "/usr/local/lib/python2.7/dist-packages/BiblioPixelAnimations/strip/LarsonScanners.py", line 22, in __init__
    self._fadeAmt = 256 / self._tail
ZeroDivisionError: integer division or modulo by zero

i did this workaround without really understanding what im doing.

 hope this helps...